### PR TITLE
Add Test for JSON Field Count

### DIFF
--- a/User Interface/Raw Java Files/Tests/JsonTest.java
+++ b/User Interface/Raw Java Files/Tests/JsonTest.java
@@ -1,0 +1,25 @@
+package Tests;
+
+import org.glbrc.glseq2.Project_Files.AttributesJSON;
+import org.glbrc.glseq2.Project_Files.Attributes;
+
+public class JsonTest {
+  {
+
+  }
+
+  static boolean runTest() {
+    Attributes att = new Attributes();
+    // The -1 is here because we don't present the RunID to the user, even
+    // though we do want to embed that into the Attribute file if possible.
+    if (AttributesJSON.size == att.getFieldNumber() - 1) {
+      System.out.println("JsonTests passed");
+      return true;
+    } else {
+      System.out.println("JsonTests failed");
+      System.out.println("Attributes JSON Size:" + AttributesJSON.size);
+      System.out.println("Attributes Class Field Number:" + att.getFieldNumber());
+      return false;
+    }
+  }
+}

--- a/User Interface/Raw Java Files/Tests/Test_Main.java
+++ b/User Interface/Raw Java Files/Tests/Test_Main.java
@@ -1,0 +1,9 @@
+package Tests;
+
+public class Test_Main {
+  public static void main(String[] args){
+    if (JsonTest.runTest()){
+      System.out.println("All tests passed");
+    }
+  }
+}


### PR DESCRIPTION
Added a test to quickly check if the JSON Enum contains the same number
of enums as there are fields available in the attributes file.